### PR TITLE
Update Scheme.plist

### DIFF
--- a/Syntaxes/Scheme.plist
+++ b/Syntaxes/Scheme.plist
@@ -88,7 +88,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>\n</string>
+					<string>(?=\n)</string>
 					<key>name</key>
 					<string>comment.line.semicolon.scheme</string>
 				</dict>


### PR DESCRIPTION
Prevent unwanted capture of first character on line after a comment.
For example, in this fragment of sandboxing policy language:
;; allow starting python
(allow process-exec (literal "/usr/bin/python"))
