### PR TITLE
Include $self, and collapse constants rule.

### DIFF
--- a/Syntaxes/Scheme.plist
+++ b/Syntaxes/Scheme.plist
@@ -44,7 +44,7 @@
 		</dict>
 		<dict>
 			<key>include</key>
-			<string>#string</string>
+			<string>#constants</string>
 		</dict>
 		<dict>
 			<key>include</key>
@@ -111,6 +111,57 @@
 					<key>name</key>
 					<string>constant.numeric.scheme</string>
 				</dict>
+				<dict>
+					<key>match</key>
+					<string>(?&lt;=[\(\s])(#\\)(space|newline|tab)(?=[\s\)])</string>
+					<key>name</key>
+					<string>constant.character.named.scheme</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>(?&lt;=[\(\s])(#\\)x[0-9A-F]{2,4}(?=[\s\)])</string>
+					<key>name</key>
+					<string>constant.character.hex-literal.scheme</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>(?&lt;=[\(\s])(#\\).(?=[\s\)])</string>
+					<key>name</key>
+					<string>constant.character.escape.scheme</string>
+				</dict>
+                                <dict>
+                                        <key>begin</key>
+                                        <string>(")</string>
+                                        <key>beginCaptures</key>
+                                        <dict>
+                                                <key>1</key>
+                                                <dict>
+                                                        <key>name</key>
+                                                        <string>punctuation.definition.string.begin.scheme</string>
+                                                </dict>
+                                        </dict>
+                                        <key>end</key>
+                                        <string>(")</string>
+                                        <key>endCaptures</key>
+                                        <dict>
+                                                <key>1</key>
+                                                <dict>
+                                                        <key>name</key>
+                                                        <string>punctuation.definition.string.end.scheme</string>
+                                                </dict>
+                                        </dict>
+                                        <key>name</key>
+                                        <string>string.quoted.double.scheme</string>
+                                        <key>patterns</key>
+                                        <array>
+                                                <dict>
+                                                        <key>match</key>
+                                                        <string>\\.</string>
+                                                        <key>name</key>
+                                                        <string>constant.character.escape.scheme</string>
+                                                </dict>
+                                        </array>
+                                </dict>
 			</array>
 		</dict>
 		<key>illegal</key>
@@ -386,7 +437,7 @@
 			<array>
 				<dict>
 					<key>include</key>
-					<string>#string</string>
+					<string>#constants</string>
 				</dict>
 				<dict>
 					<key>begin</key>
@@ -461,10 +512,6 @@
 			<key>patterns</key>
 			<array>
 				<dict>
-					<key>include</key>
-					<string>#comment</string>
-				</dict>
-				<dict>
 					<key>begin</key>
 					<string>(?x)
 						(?&lt;=\()       # preceded by (
@@ -513,15 +560,7 @@
 					<array>
 						<dict>
 							<key>include</key>
-							<string>#comment</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#sexp</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#illegal</string>
+							<string>$self</string>
 						</dict>
 					</array>
 				</dict>
@@ -575,15 +614,7 @@
 					<array>
 						<dict>
 							<key>include</key>
-							<string>#comment</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#sexp</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#illegal</string>
+							<string>$self</string>
 						</dict>
 					</array>
 				</dict>
@@ -611,55 +642,9 @@
 					<array>
 						<dict>
 							<key>include</key>
-							<string>#comment</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#sexp</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#illegal</string>
+							<string>$self</string>
 						</dict>
 					</array>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#quote-sexp</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#quote</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#language-functions</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#string</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#constants</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>(?&lt;=[\(\s])(#\\)(space|newline|tab)(?=[\s\)])</string>
-					<key>name</key>
-					<string>constant.character.named.scheme</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>(?&lt;=[\(\s])(#\\)x[0-9A-F]{2,4}(?=[\s\)])</string>
-					<key>name</key>
-					<string>constant.character.hex-literal.scheme</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>(?&lt;=[\(\s])(#\\).(?=[\s\)])</string>
-					<key>name</key>
-					<string>constant.character.escape.scheme</string>
 				</dict>
 				<dict>
 					<key>comment</key>
@@ -674,45 +659,7 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#sexp</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#illegal</string>
-				</dict>
-			</array>
-		</dict>
-		<key>string</key>
-		<dict>
-			<key>begin</key>
-			<string>(")</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.string.begin.scheme</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>(")</string>
-			<key>endCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.string.end.scheme</string>
-				</dict>
-			</dict>
-			<key>name</key>
-			<string>string.quoted.double.scheme</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>match</key>
-					<string>\\.</string>
-					<key>name</key>
-					<string>constant.character.escape.scheme</string>
+					<string>$self</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
This is my fix for #7 (strings not highlighting because of incomplete include pattern).

I've moved strings in with the other constants, and switched the (non-quote) includes to only use `$self`.
- [Lightshow for current `Scheme.plist`](https://lightshow.githubapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Ftextmate%2Fscheme.tmbundle%2F4c21b46583ef6e8adcfd09b417bbdd9579c6a4eb%2FSyntaxes%2FScheme.plist&grammar_text=&code_source=from-text&code_url=&code=%28begin%0D%0A++%3B+Comment%0D%0A++%22string%22%0D%0A++%27symbol%0D%0A++%27+symbol%0D%0A++%23t%0D%0A++%23f%0D%0A++1234%0D%0A++-1234.0e1234%0D%0A++0x09AF%0D%0A++0b010101%0D%0A++%23%5Cspace%0D%0A++%23%5Cx0A%0D%0A++%23%5Ca%0D%0A++%27%28%29%29%0D%0A%0D%0A%28define+%28x%29%0D%0A++%3B+Comment%0D%0A++%22string%22%0D%0A++%27symbol%0D%0A++%27+symbol%0D%0A++%23t%0D%0A++%23f%0D%0A++1234%0D%0A++-1234.0e1234%0D%0A++0x09AF%0D%0A++0b010101%0D%0A++%23%5Cspace%0D%0A++%23%5Cx0A%0D%0A++%23%5Ca%0D%0A++%27%28%29%29)
- [Lightshow for this pull request](https://lightshow.githubapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Fdcecile%2Fscheme.tmbundle%2F74e0e1c037e577b5587f0daa76b1a53bda3edee6%2FSyntaxes%2FScheme.plist&grammar_text=&code_source=from-text&code_url=&code=%28begin%0D%0A++%3B+Comment%0D%0A++%22string%22%0D%0A++%27symbol%0D%0A++%27+symbol%0D%0A++%23t%0D%0A++%23f%0D%0A++1234%0D%0A++-1234.0e1234%0D%0A++0x09AF%0D%0A++0b010101%0D%0A++%23%5Cspace%0D%0A++%23%5Cx0A%0D%0A++%23%5Ca%0D%0A++%27%28%29%29%0D%0A%0D%0A%28define+%28x%29%0D%0A++%3B+Comment%0D%0A++%22string%22%0D%0A++%27symbol%0D%0A++%27+symbol%0D%0A++%23t%0D%0A++%23f%0D%0A++1234%0D%0A++-1234.0e1234%0D%0A++0x09AF%0D%0A++0b010101%0D%0A++%23%5Cspace%0D%0A++%23%5Cx0A%0D%0A++%23%5Ca%0D%0A++%27%28%29%29)

I've only tested this using Github's Lightshow because I don't have a copy of TextMate. Can someone else try this in TextMate before/if it gets merged?
