### PR TITLE
Update Scheme.plist

### DIFF
--- a/Syntaxes/Scheme.plist
+++ b/Syntaxes/Scheme.plist
@@ -494,7 +494,7 @@
 							<key>name</key>
 							<string>entity.name.function.scheme</string>
 						</dict>
-						<key>4</key>
+						<key>6</key>
 						<dict>
 							<key>name</key>
 							<string>variable.parameter.function.scheme</string>


### PR DESCRIPTION
The variable.parameter.function.scheme was selecting the whole string of the parameters, along with whitespace characters. Now the autocompletion with escape will complete the parameters' names.
